### PR TITLE
Feature: to_dict(key, duplicated=reducer)

### DIFF
--- a/richset/__init__.py
+++ b/richset/__init__.py
@@ -18,6 +18,7 @@ from .comparable import Comparable
 T = TypeVar("T")
 S = TypeVar("S")
 Key = TypeVar("Key", bound=Hashable)
+OnDuplicateActions = Literal["error", "first", "last"]
 
 
 @dataclass(frozen=True)
@@ -93,7 +94,7 @@ class RichSet(Generic[T]):
         self,
         key: Callable[[T], Key],
         *,
-        duplicated: Literal["error", "first", "last"] = "error",
+        duplicated: OnDuplicateActions | Callable[[list[T]], T] = "error",
     ) -> dict[Key, T]:
         """Returns a dictionary mapping keys to values.
 
@@ -112,7 +113,7 @@ there are multiple records with the same key.
         elif duplicated == "last":
             return {k: v[-1] for k, v in base.items()}
         else:
-            raise ValueError("invalid duplicated value")
+            return {k: duplicated(v) for k, v in base.items()}
 
     def to_dict_of_list(
         self,

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -167,9 +167,21 @@ def test_richset_to_dict() -> None:
         "jane": Something(2, "jane"),
     }
 
-    with pytest.raises(ValueError) as err:
-        rs.to_dict(lambda r: r.name, duplicated="invalid")  # type: ignore
-    assert str(err.value) == "invalid duplicated value"
+    # test with a custom duplicate key function
+    assert rs.to_dict(
+        lambda r: r.name,
+        duplicated=lambda items: min(items, key=lambda item: item.id),
+    ) == {
+        "john": Something(1, "john"),
+        "jane": Something(2, "jane"),
+    }
+    assert rs.to_dict(
+        lambda r: r.name,
+        duplicated=lambda items: max(items, key=lambda item: item.id),
+    ) == {
+        "john": Something(3, "john"),
+        "jane": Something(2, "jane"),
+    }
 
 
 def test_richset_to_dict_of_list() -> None:


### PR DESCRIPTION
Allow to pass reducer to to_dict.
This makes it possible to select items according to specific conditions when keys are duplicated.
For example, it will be possible to take out the largest item and take out the smallest item.

```python
from dataclasses import dataclass
from richset import RichSet


@dataclass(frozen=True)
class Something:
    id: int
    name: str


rs = RichSet.from_list(
    [
        Something(1, "john"),
        Something(2, "jane"),
        Something(3, "john"),  # name duplicated
    ]
)

rs.to_dict(
    lambda r: r.name,
    duplicated=lambda items: min(items, key=lambda item: item.id),
)
# => {"john": Something(1, "john"), "jane": Something(2, "jane")}
rs.to_dict(
    lambda r: r.name,
    duplicated=lambda items: max(items, key=lambda item: item.id),
)
# => {"john": Something(3, "john"), "jane": Something(2, "jane")}
```

Close: https://github.com/kitsuyui/python-richset/issues/13