### PR TITLE
Feature: grouping functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ richset.symmetric_difference(richset2).to_set()  # => {Something(1, 'one'), Some
 
 Also `is_subset()`, `is_superset()`, `is_disjoint()` and `is_equal_as_set()` are available.
 
+### Grouping
+
+```python
+richset.group_by(lambda item: item.id % 2)  # => {1: RichSet(records=(Something(id=1, name='one'), Something(id=3, name='three'))), 0: RichSet(records=(Something(id=2, name='two'),))}
+richset.size_of_group_by(lambda item: item.id % 2)  # => {1: 2, 0: 1}
+richset.count_of_group_by(key=lambda item: item.id % 2, predicate=lambda item: item.name.startswith('t'))  # => {1: 1, 0: 1}
+richset.aggregate_by(key=lambda r: r.id % 2, fn=lambda a, b: a + b.name, initial='')  # => {1: 'onethree', 0: 'two'}
+```
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/richset/__init__.py
+++ b/richset/__init__.py
@@ -437,3 +437,42 @@ symmetric difference of the records."""
     def count(self, predicate: Callable[[T], bool]) -> int:
         """Returns the number of records satisfying the predicate."""
         return sum(1 for r in self.records if predicate(r))
+
+    # groupings
+
+    def group_by(
+        self,
+        key: Callable[[T], Key],
+    ) -> dict[Key, RichSet[T]]:
+        """Returns a dict of RichSets grouped by the given key."""
+        return {
+            k: RichSet.from_list(list(v))
+            for k, v in self.to_dict_of_list(key).items()
+        }
+
+    def size_of_group_by(
+        self,
+        key: Callable[[T], Key],
+    ) -> dict[Key, int]:
+        """Returns a dict of sizes of RichSets grouped by the given key."""
+        return {k: v.size() for k, v in self.group_by(key).items()}
+
+    def count_of_group_by(
+        self, *, key: Callable[[T], Key], predicate: Callable[[T], bool]
+    ) -> dict[Key, int]:
+        """Returns a dict of the number of records satisfying \
+the predicate grouped by the given key."""
+        return {k: v.count(predicate) for k, v in self.group_by(key).items()}
+
+    def aggregate_by(
+        self,
+        *,
+        key: Callable[[T], Key],
+        fn: Callable[[S, T], S],
+        initial: S,
+    ) -> dict[Key, S]:
+        """Returns a dict of aggregated values grouped by the given key."""
+        return {
+            k: v.reduce(fn, initial=initial)
+            for k, v in self.group_by(key).items()
+        }

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+
+from richset import RichSet
+
+
+@dataclass(frozen=True)
+class Something:
+    id: int
+    name: str
+
+
+def test_richset_group_by() -> None:
+    rs = RichSet.from_list(
+        [
+            Something(1, "one"),
+            Something(2, "two"),
+            Something(3, "three"),
+        ]
+    )
+    assert rs.group_by(lambda r: r.id % 2)[0] == RichSet.from_list(
+        [Something(2, "two")]
+    )
+    assert rs.group_by(lambda r: r.id % 2)[1] == RichSet.from_list(
+        [Something(1, "one"), Something(3, "three")]
+    )
+
+
+def test_richtest_size_of_group_by() -> None:
+    rs = RichSet.from_list(
+        [
+            Something(1, "one"),
+            Something(2, "two"),
+            Something(3, "three"),
+        ]
+    )
+    assert rs.size_of_group_by(lambda r: r.id % 2)[0] == 1
+    assert rs.size_of_group_by(lambda r: r.id % 2)[1] == 2
+
+
+def test_richset_count_of_group_by() -> None:
+    rs = RichSet.from_list(
+        [
+            Something(1, "one"),
+            Something(2, "two"),
+            Something(3, "three"),
+        ]
+    )
+    assert (
+        rs.count_of_group_by(
+            key=lambda r: r.id % 2,
+            predicate=lambda x: x.name.startswith("t"),
+        )[0]
+        == 1
+    )
+    assert (
+        rs.count_of_group_by(
+            key=lambda r: r.id % 2,
+            predicate=lambda x: x.name.startswith("t"),
+        )[1]
+        == 1
+    )
+    assert (
+        rs.count_of_group_by(
+            key=lambda r: r.id % 2,
+            predicate=lambda x: x.name.startswith("o"),
+        )[0]
+        == 0
+    )
+    assert (
+        rs.count_of_group_by(
+            key=lambda r: r.id % 2,
+            predicate=lambda x: x.name.startswith("o"),
+        )[1]
+        == 1
+    )
+
+
+def test_richset_aggregate_by() -> None:
+    rs = RichSet.from_list(
+        [
+            Something(1, "one"),
+            Something(2, "two"),
+            Something(3, "three"),
+        ]
+    )
+    assert rs.aggregate_by(
+        key=lambda r: r.id % 2, fn=lambda a, b: a + b.name, initial=""
+    ) == {
+        0: "two",
+        1: "onethree",
+    }


### PR DESCRIPTION
```python
from dataclasses import dataclass
from richset import RichSet

@dataclass(frozen=True)
class Something:
    id: int
    name: str

richset = RichSet.from_list([
    Something(1, 'one'),
    Something(2, 'two'),
    Something(3, 'three'),
])

richset.group_by(lambda item: item.id % 2)  # => {1: RichSet(records=(Something(id=1, name='one'), Something(id=3, name='three'))), 0: RichSet(records=(Something(id=2, name='two'),))}
richset.size_of_group_by(lambda item: item.id % 2)  # => {1: 2, 0: 1}
richset.count_of_group_by(key=lambda item: item.id % 2, predicate=lambda item: item.name.startswith('t'))  # => {1: 1, 0: 1}
richset.aggregate_by(key=lambda r: r.id % 2, fn=lambda a, b: a + b.name, initial='')  # => {1: 'onethree', 0: 'two'}
```

Close: https://github.com/kitsuyui/python-richset/issues/11