### PR TITLE
Run Coverage with matrix build

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -49,14 +49,31 @@ jobs:
         run: poetry run poe test
 
       - name: Coverage
-        run: poetry run poe coverage-xml
+        run: |
+          poetry run poe coverage-xml
+          mv coverage.xml coverage-${{ matrix.python }}.xml
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage-${{ matrix.python }}.xml
+
+  send-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: coverage-*.xml
 
       - name: Upload coverage report to Codecov
-        if: matrix.python == '3.11'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: coverage-*.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true


### PR DESCRIPTION
 ### Motivation

Currently, only the execution result of Python 3.11 is included in the coverage measurement range.
However, there are codes that are not executed in Python 3.11, such as workarounds for Python 3.8.
By using matrix build, we can get the execution result of all versions, measure the coverage, and upload it to codecov.
