### PR TITLE
Coverage Correction

### DIFF
--- a/richset/comparable.py
+++ b/richset/comparable.py
@@ -3,7 +3,7 @@ import sys
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # pragma: no cover
 
 from typing import TypeVar, Union
 


### PR DESCRIPTION
When using `from typing_extensions import Protocol` instead of `from typing import Protocol` because Python 3.7 or earlier does not
support it, there is no need to include it in the coverage measurement, so add a `no cover` comment.
By adding the `no cover` comment, you can exclude it from the coverage measurement.
