### PR TITLE
Coverage Correction (2)

### DIFF
--- a/richset/__init__.py
+++ b/richset/__init__.py
@@ -17,7 +17,7 @@ from typing import (
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # pragma: no cover
 
 from .comparable import Comparable
 


### PR DESCRIPTION
When using `from typing_extensions import Protocol` instead of `from typing import Protocol` because Python 3.7 or earlier does not
support it, there is no need to include it in the coverage measurement, so add a `no cover` comment.
By adding the `no cover` comment, you can exclude it from the coverage measurement.
