### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,35 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ANN",
+    "ARG005",
+    "D",
+    "S101",
+]

--- a/richset/__init__.py
+++ b/richset/__init__.py
@@ -2,23 +2,18 @@ from __future__ import annotations
 
 import functools
 import itertools
+from collections.abc import Callable, Hashable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import (
-    Callable,
     Generic,
-    Hashable,
-    Iterable,
-    Iterator,
+    Literal,
     TypeVar,
     overload,
 )
 
-from typing import Literal
-
-from .comparable import Comparable
-
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
+from .comparable import Comparable
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -114,12 +109,11 @@ there are multiple records with the same key.
             if len(base) != self.size():
                 raise ValueError("duplicate keys")
             return {k: v[0] for k, v in base.items()}
-        elif duplicated == "first":
+        if duplicated == "first":
             return {k: v[0] for k, v in base.items()}
-        elif duplicated == "last":
+        if duplicated == "last":
             return {k: v[-1] for k, v in base.items()}
-        else:
-            return {k: duplicated(v) for k, v in base.items()}
+        return {k: duplicated(v) for k, v in base.items()}
 
     def to_dict_of_list(
         self,
@@ -259,7 +253,7 @@ there are multiple records with the same key.
 
     def pushed(self, record: T) -> RichSet[T]:
         """Returns a new RichSet with the given record pushed to the end."""
-        return RichSet.from_tuple(self.records + (record,))
+        return RichSet.from_tuple((*self.records, record))
 
     def pushed_all(self, records: Iterable[T]) -> RichSet[T]:
         """Returns a new RichSet with the given records pushed to the end."""
@@ -268,7 +262,7 @@ there are multiple records with the same key.
     def unshifted(self, record: T) -> RichSet[T]:
         """Returns a new RichSet with the given record \
 unshifted to the beginning."""
-        return RichSet.from_tuple((record,) + self.records)
+        return RichSet.from_tuple((record, *self.records))
 
     def unshifted_all(self, records: Iterable[T]) -> RichSet[T]:
         """Returns a new RichSet with the given records \
@@ -414,27 +408,29 @@ symmetric difference of the records."""
     def cartesian_product(self, other: RichSet[S]) -> RichSet[tuple[T, S]]:
         """Returns a new RichSet with the cartesian product of the records."""
         return RichSet.from_list(
-            [(r1, r2) for r1 in self.records for r2 in other.records]
+            [(r1, r2) for r1 in self.records for r2 in other.records],
         )
 
     def zip(self, other: RichSet[S]) -> RichSet[tuple[T, S]]:
         """Returns a new RichSet with the zip of the records.
 
         This performs like the zip() function in Python."""
-        return RichSet.from_list(list(zip(self.records, other.records)))
+        return RichSet.from_list(
+            list(zip(self.records, other.records, strict=False)),
+        )
 
     @overload
     def zip_longest(
-        self, other: RichSet[S], *, fillvalue: Fill
+        self, other: RichSet[S], *, fillvalue: Fill,
     ) -> RichSet[tuple[T | Fill, S | Fill]]: ...
 
     @overload
     def zip_longest(
-        self, other: RichSet[S]
+        self, other: RichSet[S],
     ) -> RichSet[tuple[T | None, S | None]]: ...
 
     def zip_longest(
-        self, other: RichSet[S], *, fillvalue: Fill | None = None
+        self, other: RichSet[S], *, fillvalue: Fill | None = None,
     ) -> RichSet[tuple[T | Fill, S | Fill]]:
         """Returns a new RichSet with the zip_longest of the records.
 
@@ -443,12 +439,12 @@ symmetric difference of the records."""
             return RichSet.from_list(
                 list(
                     itertools.zip_longest(
-                        self.records, other.records, fillvalue=fillvalue
-                    )
-                )
+                        self.records, other.records, fillvalue=fillvalue,
+                    ),
+                ),
             )
         return RichSet.from_list(
-            list(itertools.zip_longest(self.records, other.records))
+            list(itertools.zip_longest(self.records, other.records)),
         )
 
     # sorting
@@ -505,7 +501,7 @@ symmetric difference of the records."""
         return {k: v.size() for k, v in self.group_by(key).items()}
 
     def count_of_group_by(
-        self, *, key: Callable[[T], Key], predicate: Callable[[T], bool]
+        self, *, key: Callable[[T], Key], predicate: Callable[[T], bool],
     ) -> dict[Key, int]:
         """Returns a dict of the number of records satisfying \
 the predicate grouped by the given key."""

--- a/richset/comparable.py
+++ b/richset/comparable.py
@@ -1,4 +1,4 @@
-from typing import Protocol, TypeVar, Union
+from typing import Protocol, TypeVar
 
 T_contra = TypeVar("T_contra", contravariant=True)
 
@@ -11,4 +11,4 @@ class SupportsDunderGT(Protocol[T_contra]):  # pragma: no cover
     def __gt__(self, __other: T_contra) -> bool: ...
 
 
-Comparable = Union[SupportsDunderLT[T_contra], SupportsDunderGT[T_contra]]
+Comparable = SupportsDunderLT[T_contra] | SupportsDunderGT[T_contra]

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -28,7 +28,7 @@ def test_richset_from_list() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs == RichSet.from_list([Something(1, "one"), Something(2, "two")])
 
@@ -38,7 +38,7 @@ def test_richset_to_list() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.to_list() == [Something(1, "one"), Something(2, "two")]
 
@@ -48,7 +48,7 @@ def test_richset_from_tuple() -> None:
         (
             Something(1, "one"),
             Something(2, "two"),
-        )
+        ),
     )
     assert rs.to_list() == [Something(1, "one"), Something(2, "two")]
 
@@ -58,7 +58,7 @@ def test_richset_to_tuple() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.to_tuple() == (Something(1, "one"), Something(2, "two"))
 
@@ -68,7 +68,7 @@ def test_richset_from_set() -> None:
         {
             Something(1, "one"),
             Something(2, "two"),
-        }
+        },
     )
     assert rs.to_set() == {Something(1, "one"), Something(2, "two")}
 
@@ -79,8 +79,8 @@ def test_richset_from_frozenset() -> None:
             {
                 Something(1, "one"),
                 Something(2, "two"),
-            }
-        )
+            },
+        ),
     )
     assert rs.to_set() == {Something(1, "one"), Something(2, "two")}
 
@@ -90,7 +90,7 @@ def test_richset_to_set() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.to_set() == {Something(1, "one"), Something(2, "two")}
     assert RichSet[Something].from_empty().to_set() == set({})
@@ -99,7 +99,7 @@ def test_richset_to_set() -> None:
         [
             SomethingElse(1, "one"),
             SomethingElse(2, "two"),
-        ]
+        ],
     )
     with pytest.raises(TypeError) as err:
         rs2.to_set()
@@ -111,10 +111,10 @@ def test_richset_to_frozenset() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.to_frozenset() == frozenset(
-        {Something(1, "one"), Something(2, "two")}
+        {Something(1, "one"), Something(2, "two")},
     )
     assert RichSet[Something].from_empty().to_frozenset() == set({})
 
@@ -122,7 +122,7 @@ def test_richset_to_frozenset() -> None:
         [
             SomethingElse(1, "one"),
             SomethingElse(2, "two"),
-        ]
+        ],
     )
     with pytest.raises(TypeError) as err:
         rs2.to_frozenset()
@@ -134,7 +134,7 @@ def test_richset_to_dict() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.to_dict(lambda r: r.id) == {
         1: Something(1, "one"),
@@ -146,7 +146,7 @@ def test_richset_to_dict() -> None:
             Something(1, "john"),
             Something(2, "jane"),
             Something(3, "john"),  # name duplicated
-        ]
+        ],
     )
 
     with pytest.raises(ValueError) as err:
@@ -190,7 +190,7 @@ def test_richset_to_dict_of_list() -> None:
             Something(1, "john"),
             Something(2, "jane"),
             Something(3, "john"),  # name duplicated
-        ]
+        ],
     )
     assert rs.to_dict_of_list(lambda r: r.name) == {
         "john": [Something(1, "john"), Something(3, "john")],

--- a/tests/test_factory_classmethods.py
+++ b/tests/test_factory_classmethods.py
@@ -14,6 +14,6 @@ def test_richset_from_list() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs == RichSet.from_list([Something(1, "one"), Something(2, "two")])

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -15,13 +15,13 @@ def test_richset_group_by() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.group_by(lambda r: r.id % 2)[0] == RichSet.from_list(
-        [Something(2, "two")]
+        [Something(2, "two")],
     )
     assert rs.group_by(lambda r: r.id % 2)[1] == RichSet.from_list(
-        [Something(1, "one"), Something(3, "three")]
+        [Something(1, "one"), Something(3, "three")],
     )
 
 
@@ -31,7 +31,7 @@ def test_richtest_size_of_group_by() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.size_of_group_by(lambda r: r.id % 2)[0] == 1
     assert rs.size_of_group_by(lambda r: r.id % 2)[1] == 2
@@ -43,7 +43,7 @@ def test_richset_count_of_group_by() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert (
         rs.count_of_group_by(
@@ -81,10 +81,10 @@ def test_richset_aggregate_by() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.aggregate_by(
-        key=lambda r: r.id % 2, fn=lambda a, b: a + b.name, initial=""
+        key=lambda r: r.id % 2, fn=lambda a, b: a + b.name, initial="",
     ) == {
         0: "two",
         1: "onethree",

--- a/tests/test_list_accessors.py
+++ b/tests/test_list_accessors.py
@@ -16,7 +16,7 @@ def test_richset_get_first() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.get_first() == Something(1, "one")
     assert rs.get_first(Something(-1, "default")) == Something(1, "one")
@@ -30,7 +30,7 @@ def test_richset_first() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.first() == Something(1, "one")
 
@@ -43,7 +43,7 @@ def test_richset_get_last() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.get_last() == Something(2, "two")
     assert rs.get_last(Something(-1, "default")) == Something(2, "two")
@@ -57,7 +57,7 @@ def test_richset_last() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.last() == Something(2, "two")
 
@@ -70,7 +70,7 @@ def test_richset_nth() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.nth(0) == Something(1, "one")
     assert rs.nth(1) == Something(2, "two")
@@ -86,7 +86,7 @@ def test_richset_get_nth() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.get_nth(0) == Something(1, "one")
     assert rs.get_nth(1) == Something(2, "two")
@@ -101,7 +101,7 @@ def test_richset_one() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.one() == Something(1, "one")
     with pytest.raises(IndexError) as err:
@@ -114,7 +114,7 @@ def test_richset_get_one() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.get_one() == Something(1, "one")
     assert rs.get_one(Something(-1, "default")) == Something(1, "one")

--- a/tests/test_list_functional_manipulations.py
+++ b/tests/test_list_functional_manipulations.py
@@ -15,7 +15,7 @@ def test_richset_filter() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "two"),
-        ]
+        ],
     )
     assert rs.filter(lambda r: r.id > 1).to_list() == [
         Something(2, "two"),
@@ -29,7 +29,7 @@ def test_richset_unique() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(1, "one"),
-        ]
+        ],
     )
     assert rs.unique(lambda r: r.id).to_list() == [
         Something(1, "one"),
@@ -42,7 +42,7 @@ def test_richset_map() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.map(lambda r: r.id).to_list() == [1, 2]
 
@@ -54,7 +54,7 @@ def test_richset_reduce() -> None:
             Something(2, "two"),
             Something(3, "three"),
             Something(4, "four"),
-        ]
+        ],
     )
     assert rs.reduce(lambda acc, r: acc + r.id, 0) == 10
     assert rs.reduce(lambda acc, r: acc * r.id, 1) == 24

--- a/tests/test_list_manipulations.py
+++ b/tests/test_list_manipulations.py
@@ -17,7 +17,7 @@ def test_richset_pushed() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.pushed(Something(4, "four")).to_list() == [
         Something(1, "one"),
@@ -33,7 +33,7 @@ def test_richset_pushed_all() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.pushed_all([]).to_list() == [
         Something(1, "one"),
@@ -45,7 +45,7 @@ def test_richset_pushed_all() -> None:
         [
             Something(4, "four"),
             Something(5, "five"),
-        ]
+        ],
     ).to_list() == [
         Something(1, "one"),
         Something(2, "two"),
@@ -61,7 +61,7 @@ def test_richset_unshifted() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.unshifted(Something(4, "four")).to_list() == [
         Something(4, "four"),
@@ -77,7 +77,7 @@ def test_richset_unshifted_all() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.unshifted_all([]).to_list() == [
         Something(1, "one"),
@@ -89,7 +89,7 @@ def test_richset_unshifted_all() -> None:
         [
             Something(4, "four"),
             Something(5, "five"),
-        ]
+        ],
     ).to_list() == [
         Something(4, "four"),
         Something(5, "five"),
@@ -105,7 +105,7 @@ def test_richset_popped() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
 
     item, rs2 = rs.popped()
@@ -127,7 +127,7 @@ def test_richset_popped_n() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
 
     popped_items, rs2 = rs.popped_n(2)
@@ -154,7 +154,7 @@ def test_richset_shifted() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
 
     item, rs2 = rs.shifted()
@@ -176,7 +176,7 @@ def test_richset_shifted_n() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
 
     shifted_items, rs2 = rs.shifted_n(2)
@@ -203,7 +203,7 @@ def test_richset_slice() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.slice(0, 0).to_list() == []
     assert rs.slice(1, 2).to_list() == [Something(2, "two")]
@@ -222,7 +222,7 @@ def test_richset_divide_at() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     rs2, rs3 = rs.divide_at(0)
     assert rs2.to_list() == []

--- a/tests/test_magic_methods.py
+++ b/tests/test_magic_methods.py
@@ -14,7 +14,7 @@ def test_richset_iter() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     for i, r in enumerate(rs):
         if i == 0:
@@ -28,7 +28,7 @@ def test_richset_len() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert len(rs) == 2
     assert len(RichSet[str].from_empty()) == 0

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -17,7 +17,7 @@ def test_richset_page() -> None:
             Something(3, "three"),
             Something(4, "four"),
             Something(5, "five"),
-        ]
+        ],
     )
     assert rs.page(0, 2).to_list() == [
         Something(1, "one"),
@@ -48,25 +48,25 @@ def test_richset_split_into_pages() -> None:
             Something(3, "three"),
             Something(4, "four"),
             Something(5, "five"),
-        ]
+        ],
     )
     assert rs.split_into_pages(2) == [
         RichSet.from_list(
             [
                 Something(1, "one"),
                 Something(2, "two"),
-            ]
+            ],
         ),
         RichSet.from_list(
             [
                 Something(3, "three"),
                 Something(4, "four"),
-            ]
+            ],
         ),
         RichSet.from_list(
             [
                 Something(5, "five"),
-            ]
+            ],
         ),
     ]
     assert rs.split_into_pages(3) == [
@@ -75,13 +75,13 @@ def test_richset_split_into_pages() -> None:
                 Something(1, "one"),
                 Something(2, "two"),
                 Something(3, "three"),
-            ]
+            ],
         ),
         RichSet.from_list(
             [
                 Something(4, "four"),
                 Something(5, "five"),
-            ]
+            ],
         ),
     ]
     assert rs.split_into_pages(4) == [
@@ -91,12 +91,12 @@ def test_richset_split_into_pages() -> None:
                 Something(2, "two"),
                 Something(3, "three"),
                 Something(4, "four"),
-            ]
+            ],
         ),
         RichSet.from_list(
             [
                 Something(5, "five"),
-            ]
+            ],
         ),
     ]
     assert rs.split_into_pages(5) == [
@@ -107,7 +107,7 @@ def test_richset_split_into_pages() -> None:
                 Something(3, "three"),
                 Something(4, "four"),
                 Something(5, "five"),
-            ]
+            ],
         ),
     ]
     assert rs.split_into_pages(6) == [
@@ -118,6 +118,6 @@ def test_richset_split_into_pages() -> None:
                 Something(3, "three"),
                 Something(4, "four"),
                 Something(5, "five"),
-            ]
+            ],
         ),
     ]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,7 +17,7 @@ def test_richset_index_of() -> None:
             Something(3, "three"),
             Something(4, "four"),
             Something(5, "five"),
-        ]
+        ],
     )
     assert rs.index_of(lambda r: r.id == 1) == 0
     assert rs.index_of(lambda r: r.id == 2) == 1
@@ -46,7 +46,7 @@ def test_richset_indices() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.indices_of(lambda r: r.id == 1) == [0]
     assert rs.indices_of(lambda r: r.id == 2) == [1]
@@ -59,7 +59,7 @@ def test_richset_search_first() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.search_first(lambda r: r.id == 0) == (-1, None)
     assert rs.search_first(lambda r: r.id == 1) == (0, Something(1, "one"))
@@ -74,7 +74,7 @@ def test_richset_search_last() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.search_last(lambda r: r.id == 0) == (-1, None)
     assert rs.search_last(lambda r: r.id == 1) == (0, Something(1, "one"))
@@ -89,7 +89,7 @@ def test_richset_search_all() -> None:
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs.search_all(lambda r: r.id == 0) == []
     assert rs.search_all(lambda r: r.id == 1) == [(0, Something(1, "one"))]
@@ -105,7 +105,7 @@ def test_richset_contains() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.contains(lambda x: x.id == 1)
     assert rs.contains(lambda x: x.id == 2)
@@ -117,7 +117,7 @@ def test_richset_has() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.has(Something(1, "one"))
     assert rs.has(Something(2, "two"))

--- a/tests/test_set_operations.py
+++ b/tests/test_set_operations.py
@@ -20,13 +20,13 @@ def test_richset_union() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.union(rs2).to_set() == {
         Something(1, "one"),
@@ -41,13 +41,13 @@ def test_richset_intersection() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.intersection(rs2).to_set() == {Something(1, "one")}
     assert rs1.intersection(rs2).to_set() == rs2.intersection(rs1).to_set()
@@ -58,13 +58,13 @@ def test_richset_difference() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.difference(rs2).to_set() == {Something(2, "two")}
     assert rs2.difference(rs1).to_set() == {Something(3, "three")}
@@ -75,13 +75,13 @@ def test_richset_symmetric_difference() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.symmetric_difference(rs2).to_set() == {
         Something(2, "two"),
@@ -97,13 +97,13 @@ def test_richset_is_subset() -> None:
     rs1 = RichSet.from_list(
         [
             Something(1, "one"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.is_subset(rs2)
     assert not rs2.is_subset(rs1)
@@ -116,12 +116,12 @@ def test_richset_is_superset() -> None:
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
-        ]
+        ],
     )
     assert rs1.is_superset(rs2)
     assert not rs2.is_superset(rs1)
@@ -134,19 +134,19 @@ def test_richset_is_disjoint() -> None:
         [
             Something(1, "one"),
             Something(3, "three"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs3 = RichSet.from_list(
         [
             Something(3, "three"),
             Something(4, "four"),
-        ]
+        ],
     )
     assert not rs1.is_disjoint(rs2)
     assert not rs2.is_disjoint(rs1)
@@ -169,20 +169,20 @@ def test_richset_is_equal_as_set() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs3 = RichSet.from_list(
         [
             Something(1, "one"),
             Something(2, "two"),
             Something(3, "three"),
-        ]
+        ],
     )
     assert rs1.is_equal_as_set(rs2)
     assert rs2.is_equal_as_set(rs1)
@@ -203,13 +203,13 @@ def test_richset_cartesian_product() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Foo(3, "three"),
             Foo(4, "four"),
-        ]
+        ],
     )
     assert rs1.cartesian_product(rs2).to_set() == {
         (Something(1, "one"), Foo(3, "three")),
@@ -224,14 +224,14 @@ def test_richset_zip() -> None:
         [
             Something(1, "one"),
             Something(2, "two"),
-        ]
+        ],
     )
     rs2 = RichSet.from_list(
         [
             Foo(3, "three"),
             Foo(4, "four"),
             Foo(5, "five"),
-        ]
+        ],
     )
     assert rs1.zip(rs2).to_set() == {
         (Something(1, "one"), Foo(3, "three")),

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -15,7 +15,7 @@ def test_richset_sorted() -> None:
             Something(1, "one"),
             Something(3, "three"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.sorted(key=lambda r: r.id).to_list() == [
         Something(1, "one"),
@@ -42,7 +42,7 @@ def test_richset_reversed() -> None:
             Something(1, "one"),
             Something(3, "three"),
             Something(2, "two"),
-        ]
+        ],
     )
     assert rs.reversed().to_list() == [
         Something(2, "two"),

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -29,15 +29,15 @@ def test_richset_size() -> None:
             [
                 Something(1, "one"),
                 Something(2, "two"),
-            ]
+            ],
         ).size()
         == 2
     )
 
 
 def test_richset_count() -> None:
-    assert RichSet.from_list([]).count(lambda r: True) == 0
-    assert RichSet.from_list([]).count(lambda r: False) == 0
+    assert RichSet.from_list([]).count(lambda _: True) == 0
+    assert RichSet.from_list([]).count(lambda _: False) == 0
     rs = RichSet.from_list([Something(1, "one"), Something(2, "two")])
     assert rs.count(lambda r: r.id == 1) == 1
     assert rs.count(lambda r: r.id > 0) == 2
@@ -47,7 +47,7 @@ def test_richset_count() -> None:
                 Something(1, "one"),
                 Something(2, "two"),
                 Something(3, "three"),
-            ]
+            ],
         ).count(lambda r: r.id % 2 == 0)
         == 1
     )


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
