### PR TITLE
Pin gitignore update action

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -13,4 +13,4 @@ jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitignore-in/gh-action@v0.2.3
+      - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4


### PR DESCRIPTION
## Summary

- Pin `.github/workflows/gitignore-in.yml` to the `gitignore-in/gh-action` commit currently referenced by `v0.2.3`.
- Keep the repository-write scheduled workflow tied to immutable action source instead of a mutable tag.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gitignore-in.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/gitignore-in.yml`
- `actionlint .github/workflows/*.yml`
