### PR TITLE
Pin reusable workflow refs

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary
- Pin the reusable happy-commit and gitignore update workflows to full commit SHAs instead of the moving `main` ref.

## Verification
- `git diff --check`
- `actionlint .github/workflows/happy.yml .github/workflows/gitignore-in.yml`
- Verified both pinned workflow files are resolvable through the GitHub API.