### PR TITLE
Make zip() raise ValueError when argument lengths differ

### DIFF
--- a/richset/_richset.py
+++ b/richset/_richset.py
@@ -426,9 +426,11 @@ symmetric difference of the records."""
     def zip(self, other: RichSet[S]) -> RichSet[tuple[T, S]]:
         """Returns a new RichSet with the zip of the records.
 
-        This performs like the zip() function in Python."""
+        Both RichSets must have the same number of elements;
+        raises ValueError if their lengths differ.
+        Use zip_longest() to pair sequences of unequal length."""
         return RichSet.from_list(
-            list(zip(self.records, other.records, strict=False)),
+            list(zip(self.records, other.records, strict=True)),
         )
 
     @overload

--- a/tests/test_set_operations.py
+++ b/tests/test_set_operations.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import pytest
+
 from richset import RichSet
 
 
@@ -230,13 +232,35 @@ def test_richset_zip() -> None:
         [
             Foo(3, "three"),
             Foo(4, "four"),
-            Foo(5, "five"),
         ],
     )
     assert rs1.zip(rs2).to_set() == {
         (Something(1, "one"), Foo(3, "three")),
         (Something(2, "two"), Foo(4, "four")),
     }
+
+
+def test_richset_zip_unequal_length_raises() -> None:
+    rs1 = RichSet.from_list([Something(1, "one"), Something(2, "two")])
+    rs2 = RichSet.from_list([Foo(3, "three"), Foo(4, "four"), Foo(5, "five")])
+    with pytest.raises(ValueError):
+        rs1.zip(rs2)
+
+
+def test_richset_zip_longest() -> None:
+    rs1 = RichSet.from_list(
+        [
+            Something(1, "one"),
+            Something(2, "two"),
+        ],
+    )
+    rs2 = RichSet.from_list(
+        [
+            Foo(3, "three"),
+            Foo(4, "four"),
+            Foo(5, "five"),
+        ],
+    )
     assert rs1.zip_longest(rs2).to_set() == {
         (Something(1, "one"), Foo(3, "three")),
         (Something(2, "two"), Foo(4, "four")),


### PR DESCRIPTION
## Summary

`zip()` used `strict=False`, silently truncating elements when two
RichSets had different lengths. A caller expecting all elements to be
paired would receive a shorter-than-expected result with no indication
that data was dropped.

## Changes

- `strict=False` → `strict=True` in `zip()`
- Docstring updated to document the equal-length requirement and point
  to `zip_longest()` for unequal-length pairing
- `test_richset_zip` split into three focused tests:
  - equal-length zip works correctly
  - unequal-length raises `ValueError`
  - `zip_longest` with unequal lengths fills missing values

## Verification

```
uv run poe check  # passes
uv run poe test   # 67 passed
```

## Trade-offs

This is a breaking change for callers relying on the silent-truncation
behavior. The intent of `zip()` on a sequence type is equal-length
pairing; callers that need padding should use `zip_longest()` instead.
