### PR TITLE
Document stable sort guarantee and add tie-breaking test for sorted()

### DIFF
--- a/richset/_richset.py
+++ b/richset/_richset.py
@@ -476,7 +476,12 @@ symmetric difference of the records."""
         key: Callable[[T], Comparable[S]],
         reverse: bool = False,
     ) -> RichSet[T]:
-        """Returns a new RichSet sorted bythe given key."""
+        """Returns a new RichSet sorted by the given key.
+
+        This sort is stable: elements with equal keys preserve their original
+        insertion order, relying on Python's guaranteed stable sort (CPython
+        2.2+). This stability guarantee is part of the RichSet API contract.
+        """
         sorted_ = tuple(sorted(self.records, key=key, reverse=reverse))
         return RichSet.from_tuple(sorted_)
 

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -36,6 +36,29 @@ def test_richset_sorted() -> None:
     ]
 
 
+def test_richset_sorted_stable() -> None:
+    # Elements with equal keys must preserve their original insertion order
+    # (stable sort contract).
+    rs = RichSet.from_list(
+        [
+            Something(1, "first"),
+            Something(1, "second"),
+            Something(1, "third"),
+        ],
+    )
+    assert rs.sorted(key=lambda r: r.id).to_list() == [
+        Something(1, "first"),
+        Something(1, "second"),
+        Something(1, "third"),
+    ]
+
+    assert rs.sorted(key=lambda r: r.id, reverse=True).to_list() == [
+        Something(1, "first"),
+        Something(1, "second"),
+        Something(1, "third"),
+    ]
+
+
 def test_richset_reversed() -> None:
     rs = RichSet.from_list(
         [


### PR DESCRIPTION
## Summary

`RichSet.sorted()` uses Python's built-in `sorted()` internally, which guarantees a stable sort: elements with equal keys preserve their original insertion order. This guarantee was not documented in the public API contract.

## Changes

- **`richset/__init__.py`**: Fix typo ("bythe" → "by the") and extend the `sorted()` docstring to explicitly document the stable sort guarantee.
- **`tests/test_sorting.py`**: Add `test_richset_sorted_stable` to cover the tie-breaking case and prevent regressions on this contract.

## Why this matters

Without this documentation, callers who rely on stable sorting for composite sort patterns (e.g. sort by primary key, preserve insertion order on ties) have no API guarantee to cite. The implementation could change (e.g. an optimized or Cython-based backend) without the contract being noticed.

## Verification

```sh
uv run poe check  # ruff + mypy: all passed
uv run poe test   # 66/66 tests passed
```
