### PR TITLE
Document first-wins deduplication order in unique()

### DIFF
--- a/richset/_richset.py
+++ b/richset/_richset.py
@@ -222,7 +222,12 @@ there are multiple records with the same key.
         return RichSet.from_list(list(filter(f, self.records)))
 
     def unique(self, key: Callable[[T], Key]) -> RichSet[T]:
-        """Returns a new RichSet with unique records."""
+        """Returns a new RichSet with unique records.
+
+        When multiple records share the same key, the first occurrence is kept
+        (first-wins). This is consistent with insertion order of the original
+        iterable. Use ``to_dict(duplicated='last')`` when last-wins is
+        needed."""
         new_records = []
         seen = set()
         for r in self.records:

--- a/tests/test_list_functional_manipulations.py
+++ b/tests/test_list_functional_manipulations.py
@@ -37,6 +37,18 @@ def test_richset_unique() -> None:
     ]
 
 
+def test_richset_unique_first_wins() -> None:
+    rs = RichSet.from_list(
+        [
+            Something(1, "first"),
+            Something(1, "second"),
+            Something(2, "only"),
+        ],
+    )
+    result = rs.unique(lambda r: r.id).to_list()
+    assert result == [Something(1, "first"), Something(2, "only")]
+
+
 def test_richset_map() -> None:
     rs = RichSet.from_list(
         [


### PR DESCRIPTION
## Summary

`unique(key)` kept the first occurrence among duplicates but the docstring only said "Returns a new RichSet with unique records." — without stating *which* record is kept. Callers expecting last-wins behavior could get silently wrong results.

This PR updates the docstring to make the first-wins guarantee explicit and adds a test that asserts the first occurrence is retained when two records share the same key but differ in value.

## Changes

- `richset/__init__.py`: expand `unique()` docstring to document first-wins behavior
- `tests/test_list_functional_manipulations.py`: add `test_richset_unique_first_wins`

## Test plan

- [x] `pytest` — 66 tests pass
- [x] `ruff check` — 0 findings
