### PR TITLE
docs: clarify page() offset and split_into_pages() size semantics

### DIFF
--- a/richset/_richset.py
+++ b/richset/_richset.py
@@ -551,16 +551,32 @@ the predicate grouped by the given key."""
         offset: int,
         limit: int,
     ) -> RichSet[T]:
-        """Returns a new RichSet with the records \
-in the given page (offset and limit)."""
+        """Returns a new RichSet with the records in the given page.
+
+        Args:
+            offset: 0-based record index to start from (records to skip,
+                not a page number). offset=0 starts from the first record;
+                offset=10 skips the first 10 records.
+            limit: Maximum number of records to return (records per page).
+
+        Returns:
+            A new RichSet containing records[offset:offset+limit].
+        """
         return RichSet.from_tuple(self.records[offset : offset + limit])
 
     def split_into_pages(
         self,
         size: int,
     ) -> list[RichSet[T]]:
-        """Returns a list of RichSets with the records \
-split into pages (limit)."""
+        """Returns a list of RichSets with the records split into pages.
+
+        Args:
+            size: Number of records per page. The last page may contain fewer
+                records if the total count is not evenly divisible by size.
+
+        Returns:
+            A list of RichSets, each containing at most ``size`` records.
+        """
         return [
             self.page(offset=offset, limit=size)
             for offset in range(0, self.size(), size)


### PR DESCRIPTION
## Summary

The `page()` and `split_into_pages()` methods lacked clear documentation of their parameter semantics, which could cause misuse:

- `page(offset, limit)`: `offset` is a **0-based record index** (number of records to skip), not a page number. Callers familiar with 1-based REST pagination or SQL-style page numbers could misinterpret this.
- `split_into_pages(size)`: `size` is **records per page**, not a page count. The parameter name alone does not convey this.

## Changes

- `richset/__init__.py`: Added Args/Returns docstrings to `page()` and `split_into_pages()` clarifying that `offset` is a 0-based record index and `size` is records per page.

## Verification

- `uv run poe check` — all checks passed (ruff + mypy)
- `uv run poe test` — 65 passed
- Adjacent static check: `ruff check --select=D` — pre-existing issues only, no regressions introduced
