### PR TITLE
Add FutureWarning to one() and get_one() to signal upcoming behavior change

### DIFF
--- a/richset/_richset.py
+++ b/richset/_richset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import itertools
+import warnings
 from collections.abc import Callable, Hashable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import (
@@ -194,12 +195,23 @@ there are multiple records with the same key.
         return default
 
     def one(self) -> T:
-        """Returns the one record in the RichSet.
+        """Returns a record from the RichSet when order does not matter.
 
-        Currently this method is exactly equivalent to `first()`.
-        But this method is intended to be used in uncertain order.
-        So this method might not returns not the first record in the future.
+        Use this when you only need one record and do not care which one.
+        For insertion-order guarantees, use ``first()`` instead.
+
+        .. warning::
+            The current implementation returns the first record, but this
+            behavior is not guaranteed and may change in a future version.
         """
+        warnings.warn(
+            "one() currently returns the first record, but this "
+            "implementation detail is not guaranteed and may change "
+            "in a future version. "
+            "For insertion-order guarantees, use first() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self.first()
 
     @overload
@@ -209,10 +221,23 @@ there are multiple records with the same key.
     def get_one(self, default: S) -> T | S: ...
 
     def get_one(self, default: S | None = None) -> T | S | None:
-        """Returns the one record in the RichSet
-        or default value (None) if the RichSet is empty.
+        """Returns a record from the RichSet, or a default value if empty.
 
-        See also `one()`."""
+        Use this when you only need one record and do not care which one.
+        For insertion-order guarantees, use ``get_first()`` instead.
+
+        .. warning::
+            The current implementation returns the first record, but this
+            behavior is not guaranteed and may change in a future version.
+        """
+        warnings.warn(
+            "get_one() currently returns the first record, but this "
+            "implementation detail is not guaranteed and may change "
+            "in a future version. "
+            "For insertion-order guarantees, use get_first() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self.get_first(default)
 
     # list manipulations

--- a/tests/test_list_accessors.py
+++ b/tests/test_list_accessors.py
@@ -103,8 +103,9 @@ def test_richset_one() -> None:
             Something(2, "two"),
         ],
     )
-    assert rs.one() == Something(1, "one")
-    with pytest.raises(IndexError) as err:
+    with pytest.warns(FutureWarning, match="one()"):
+        assert rs.one() == Something(1, "one")
+    with pytest.warns(FutureWarning), pytest.raises(IndexError) as err:
         RichSet.from_list([]).one()
     assert str(err.value) == "RichSet is empty"
 
@@ -116,8 +117,13 @@ def test_richset_get_one() -> None:
             Something(2, "two"),
         ],
     )
-    assert rs.get_one() == Something(1, "one")
-    assert rs.get_one(Something(-1, "default")) == Something(1, "one")
+    with pytest.warns(FutureWarning, match="get_one()"):
+        assert rs.get_one() == Something(1, "one")
+    with pytest.warns(FutureWarning):
+        assert rs.get_one(Something(-1, "default")) == Something(1, "one")
     rs2 = RichSet[Something].from_list([])
-    assert rs2.get_one() is None
-    assert rs2.get_one(Something(-1, "default")) == Something(-1, "default")
+    with pytest.warns(FutureWarning):
+        assert rs2.get_one() is None
+    with pytest.warns(FutureWarning):
+        result = rs2.get_one(Something(-1, "default"))
+    assert result == Something(-1, "default")


### PR DESCRIPTION
## Summary

The docstring for `one()` and `get_one()` mentioned that their behavior might
change in a future version, but no programmatic warning was emitted. Callers
who relied on insertion-order behavior through these methods had no runtime
signal to prompt them to migrate.

This PR adds `FutureWarning` to both methods so that users receive a clear
warning to switch to `first()` or `get_first()` when they need guaranteed
first-record semantics.

## Changes

- `richset/__init__.py`: Add `import warnings`; rewrite `one()` and `get_one()`
  docstrings to clearly document order-agnostic semantics; emit `FutureWarning`
  with a migration message in each method body.
- `tests/test_list_accessors.py`: Update `test_richset_one` and
  `test_richset_get_one` to assert that `FutureWarning` is emitted.

## Verification

- `uv run poe format` — no diff after formatting
- `uv run poe check` — all checks pass (ruff + mypy)
- `uv run poe test` — 65 tests passed

## Trade-offs

`one()` and `get_one()` now emit a warning on every call. Callers who
intentionally use these methods with order-agnostic semantics will see the
warning until the future behavior is defined. At that point, the warning
message and category can be updated or the warning removed.
