### PR TITLE
ci: migrate PyPI publish to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,13 +45,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Migrate PyPI and Test PyPI publish workflow from legacy API token authentication to OIDC Trusted Publisher.

**Changes:**
- Add `id-token: write` permission to the `deploy` job
- Remove `user: __token__` and `password: ${{ secrets.PYPI_API_TOKEN }}` / `${{ secrets.TEST_PYPI_API_TOKEN }}` from publish steps

## Motivation

PyPI is deprecating legacy API token authentication in favour of [OIDC Trusted Publisher](https://docs.pypi.org/trusted-publishers/). Switching to OIDC:
- Eliminates the need to store PyPI API tokens as repository secrets
- Removes the burden of token rotation / expiry management
- Scopes authentication to a specific workflow, following the principle of least privilege

## Prerequisites

Before merging this PR, the repository owner must configure a Trusted Publisher on both:
- [pypi.org Trusted Publisher settings](https://pypi.org/manage/account/publishing/)
- [test.pypi.org Trusted Publisher settings](https://test.pypi.org/manage/account/publishing/)

Configuration values:
- Repository owner: `kitsuyui`
- Repository name: `python-richset`
- Workflow filename: `pypi-publish.yml`
- Environment name: (none)

## Test plan

- [x] `uv run poe check` passes (ruff + mypy)
- [x] `uv run poe test` passes (65 tests)
- [x] `actionlint .github/workflows/pypi-publish.yml` reports no issues
- [ ] PyPI Trusted Publisher configured (human prerequisite before merge)