### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,34 @@ richset.page(offset=1, limit=2).to_list()  # => [Something(2, 'two'), Something(
 richset.split_into_pages(2).to_list()  # => [RichSet([Something(1, 'one'), Something(2, 'two')]), RichSet([Something(3, 'three')])]
 ```
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as
+CI locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check` (ruff + mypy)
+- **pre-push**: `uv run poe check` and `uv run poe test` (pytest)
+
+You can also run the checks manually:
+
+```sh
+uv run poe check  # lint + type check
+uv run poe test   # run tests
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring
+that feedback earlier on your machine.
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

Run the same checks as CI locally via Git hooks, so that lint, type, and test
failures surface before they reach CI.

The GitHub Actions CI is **kept unchanged** — Actions are free for public
repositories. The hooks only bring that feedback earlier on a developer's
machine.

## Changes

- `lefthook.yml`
  - pre-commit: `uv run poe check` (ruff + mypy)
  - pre-push: `uv run poe check` and `uv run poe test` (pytest)
- `README.md`: add a Development section documenting `uv sync` →
  `lefthook install` and what each hook runs.

## Verification

- `uv run poe check` (ruff + mypy) and `uv run poe test` (77 passed) pass
  locally.
- pre-commit / pre-push hooks fire and pass.

## Notes

Using the hooks requires [lefthook](https://lefthook.dev/) on your PATH
(documented in the README). No CI workflow is changed.
