### PR TITLE
ci: enforce minimum coverage with octocov

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.xml
+  acceptable: 95%
 codeToTestRatio:
   code:
     - "**/*.py"


### PR DESCRIPTION
## Summary
Raise the octocov acceptable coverage threshold to 95%.

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`

## Notes
- The octocov CLI is not installed locally, so the final action-level validation will run in GitHub Actions.
